### PR TITLE
24 replace unknown document icon with video icon

### DIFF
--- a/classes/util.php
+++ b/classes/util.php
@@ -63,6 +63,8 @@ class util {
                 ),
                 'author' => $presentation['Creator'],
                 'icon' => $OUTPUT->image_url(file_mimetype_icon('video/mp4'))->out(false),
+                "thumbnail_width" => 400,
+                "thumbnail_height" => 400,
                 'mimetype' => 'Video',
                 'duration' => $duration,
                 'duration_formatted' => $duration > 0 ? self::format_duration($duration) : '',


### PR DESCRIPTION
This pull request makes a small update to the `get_mediasite_presentations` function in `classes/util.php` to enhance the returned presentation data with additional media-related metadata.

- Media presentation enhancements:
  * Added an `icon` field to each presentation, using `$OUTPUT->image_url` to provide a mimetype-specific icon for video files.
  * Added `thumbnail_width` and `thumbnail_height` fields, both set to 400, to standardize thumbnail dimensions for presentations.
  * Included `$OUTPUT` in the global scope to support the new icon field.